### PR TITLE
レスポンスの形を合わせるようにした

### DIFF
--- a/common/response.js
+++ b/common/response.js
@@ -1,0 +1,36 @@
+
+/**
+ * レスポンスを作成する
+ * 
+ * @param {string} type 
+ * @param {Object} message 
+ * @returns 
+ */
+function createResponse(type, message) {
+    return {
+        type: type,
+        message: message
+    };
+}
+
+/**
+ * 成功のレスポンスを作成する
+ * 
+ * @param {Object} message 
+ * @returns 
+ */
+function successResponse(message) {
+    return createResponse("success", message);
+}
+
+/**
+ * 失敗のレスポンスを作成する
+ * 
+ * @param {Object} message 
+ * @returns 
+ */
+function errorResponse(message) {
+    return createResponse("error", message);
+}
+
+export {successResponse, errorResponse}

--- a/data/users.json
+++ b/data/users.json
@@ -1,1 +1,51 @@
-[{"ID":1,"name":"もっく","pass":"566a95423e143400c87b50ce4bbc66543af50452e07614feae77e4b8563dbdb6","session":0.48435738947308793,"is_active":true,"fitness":[],"friend_ID":[2,3,4]},{"ID":2,"name":"てる","pass":"0101cc66f2fc49c641e3a69acdab227df22e0bbe71177a864441c5d2a36e77b0","session":0.8505081111246169,"is_active":true,"fitness":[],"friend_ID":[]},{"ID":3,"name":"みやけん","pass":"64b1f7bb3371f4bf1723b40997f162851c818409d2d6455dbf1f2fef7111bc8a","session":0.018407780186298295,"is_active":false,"fitness":[],"friend_ID":[]},{"ID":4,"name":"追加野郎a","pass":"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb","session":0.15001652548641875,"is_active":true,"fitness":[],"friend_ID":[]}]
+[
+  {
+    "ID": 1,
+    "name": "もっく",
+    "pass": "566a95423e143400c87b50ce4bbc66543af50452e07614feae77e4b8563dbdb6",
+    "session": 0.48435738947308793,
+    "is_active": true,
+    "fitness": [],
+    "friend_ID": [
+      2,
+      3,
+      4
+    ]
+  },
+  {
+    "ID": 2,
+    "name": "てる",
+    "pass": "0101cc66f2fc49c641e3a69acdab227df22e0bbe71177a864441c5d2a36e77b0",
+    "session": 0.8505081111246169,
+    "is_active": true,
+    "fitness": [],
+    "friend_ID": []
+  },
+  {
+    "ID": 3,
+    "name": "みやけん",
+    "pass": "64b1f7bb3371f4bf1723b40997f162851c818409d2d6455dbf1f2fef7111bc8a",
+    "session": 0.018407780186298295,
+    "is_active": false,
+    "fitness": [],
+    "friend_ID": []
+  },
+  {
+    "ID": 4,
+    "name": "追加野郎a",
+    "pass": "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+    "session": 0.15001652548641875,
+    "is_active": true,
+    "fitness": [],
+    "friend_ID": []
+  },
+  {
+    "ID": 5,
+    "name": "よしろー",
+    "pass": "ef51306214d9a6361ee1d5b452e6d2bb70dc7ebb85bf9e02c3d4747fb57d6bec",
+    "session": 0.695475755446046,
+    "is_active": true,
+    "fitness": [],
+    "friend_ID": []
+  }
+]

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 import { Server } from "https://js.sabae.cc/Server.js";
 import { jsonfs } from "https://js.sabae.cc/jsonfs.js";
-import {WsServer} from "./ws/wsServer.js";
+import { successResponse, errorResponse } from "./common/response.js";
+//import {WsServer} from "./ws/wsServer.js";
 
 import {active_friend, get_active, get_ID_user} from "./active_friend.js";
 import {check_session,login_check} from "./check_session.js";
@@ -53,7 +54,7 @@ class MyServer extends Server {
         ID:id,
         session:ses
       }
-      return res;
+      return successResponse(res);
     } else if (path=="/api/get_active_ID"){
       //アクティブユーザのID検索用API
       //call:("api/get_active_ID"),return:[num, ...]
@@ -130,4 +131,4 @@ class MyServer extends Server {
 }
 
 new MyServer(8001);
-WsServer(8002);
+//WsServer(8002);


### PR DESCRIPTION
`server.js` に `import { successResponse, errorResponse } from "./common/response.js";` を追加
returnで返しているところで `successResponse(res)` みたいな感じにしてあげると今まで返していたオブジェクトはmessageに入ります。
```json
{"type":"success","message":{"ID":5,"session":0.695475755446046}}
```
APIごとに分割しているところはそれぞれの `js` で `successResponse` or `errorResponse` を適宜返してあげるとよさそう